### PR TITLE
URL shortening speed improvement

### DIFF
--- a/brevisurl/backends/local.py
+++ b/brevisurl/backends/local.py
@@ -65,7 +65,7 @@ class BrevisUrlBackend(BaseBrevisUrlBackend):
                                                             original_url=original_url,
                                                             shortened_url=shortened_url)
                         log.info('Url "%s" shortened to "%s"', original_url, shortened_url)
-                        transaction.savepoint_commit()
+                        transaction.savepoint_commit(sid)
                         return short_url
                     except (IntegrityError, ValidationError) as e:
                         transaction.savepoint_rollback(sid)

--- a/brevisurl/backends/local.py
+++ b/brevisurl/backends/local.py
@@ -2,10 +2,10 @@ import math
 import random
 import logging
 
-from django.db import IntegrityError, transaction
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
+from django.db import IntegrityError, transaction
 
 import brevisurl.settings
 from brevisurl import Error
@@ -65,6 +65,7 @@ class BrevisUrlBackend(BaseBrevisUrlBackend):
                                                             original_url=original_url,
                                                             shortened_url=shortened_url)
                         log.info('Url "%s" shortened to "%s"', original_url, shortened_url)
+                        transaction.savepoint_commit()
                         return short_url
                     except (IntegrityError, ValidationError) as e:
                         transaction.savepoint_rollback(sid)

--- a/brevisurl/migrations/0002_auto__add_index_shorturl_original_url.py
+++ b/brevisurl/migrations/0002_auto__add_index_shorturl_original_url.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding index on 'ShortUrl', fields ['original_url']
+        db.create_index('brevisurl_shorturl', ['original_url'])
+
+
+    def backwards(self, orm):
+        # Removing index on 'ShortUrl', fields ['original_url']
+        db.delete_index('brevisurl_shorturl', ['original_url'])
+
+
+    models = {
+        'brevisurl.shorturl': {
+            'Meta': {'ordering': "['-created']", 'unique_together': "(('original_url_hash', 'backend'),)", 'object_name': 'ShortUrl'},
+            'backend': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'original_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'db_index': 'True'}),
+            'original_url_hash': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'shortened_url': ('django.db.models.fields.URLField', [], {'unique': 'True', 'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['brevisurl']

--- a/brevisurl/models.py
+++ b/brevisurl/models.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class ShortUrl(models.Model):
     """Model that represents shortened url."""
     original_url = models.URLField(max_length=brevisurl.settings.LOCAL_BACKEND_ORIGINAL_URL_MAX_LENGTH,
-                                   null=False, blank=False)
+                                   null=False, blank=False, db_index=True)
     original_url_hash = models.CharField(max_length=64, null=False, blank=False)
     shortened_url = models.URLField(max_length=200, null=False, blank=False, unique=True)
     backend = models.CharField(max_length=200, null=False, blank=False)

--- a/brevisurl/tests/backends/test_local.py
+++ b/brevisurl/tests/backends/test_local.py
@@ -1,11 +1,15 @@
+from django.db import transaction
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.core.validators import URLValidator
 
 import brevisurl.settings
 from brevisurl import get_connection
 from brevisurl.models import ShortUrl
 from brevisurl.backends.local import TokensExhaustedError
+
+import random
+
 
 
 class TestLocalBrevisUrlBackend(TestCase):
@@ -129,3 +133,20 @@ class TestLocalBrevisUrlBackend(TestCase):
         connection = get_connection('brevisurl.backends.local.BrevisUrlBackend', domain='http://test.com/d/')
         short_url = connection.shorten_url(original_url)
         self.assertRegexpMatches(short_url.shortened_url, r'^http://test\.com/d/[^/]{5}$')
+
+class TestDuration(TransactionTestCase):
+    
+    def setUp(self):
+        self.connection = get_connection('brevisurl.backends.local.BrevisUrlBackend')
+
+    def test_shorten_urls_duration(self):
+        for i in range(0, 10000):
+            url = 'http://www.codescale.net/%s' % random.getrandbits(30)
+            self.connection.shorten_url(url)
+
+    @transaction.commit_on_success
+    def test_shorten_urls_duration_commit_on_success(self):
+        for i in range(0, 10000):
+            url = 'http://www.codescale.net/%s' % random.getrandbits(30)
+            self.connection.shorten_url(url)  
+    


### PR DESCRIPTION
I've made some improvements in the way ShortUrl objects are created:
-add database index for original_url field;
-use get_or_create QuerySet method;
-if exception occurs, other than URL validation (violation of unique constraint) repeat
 the process of generating shortened_url and checking for token exhaustion until object 
 is created.

I also perform tests using python timeit module with PostgreSQL database creating 
10000 records.

Results (in seconds):
Before changes:
using autocommit mode:    201.8245
with commit_on_success: 104.3924

After:
using autocommit mode:   146.3360 
with commit_on_success:  48.5006
