### PR TITLE
use get_or_create for shorten_url retries

### DIFF
--- a/brevisurl/backends/local.py
+++ b/brevisurl/backends/local.py
@@ -61,10 +61,16 @@ class BrevisUrlBackend(BaseBrevisUrlBackend):
                     shortened_url = self.__generate_shortened_url(domain)
                     sid = transaction.savepoint()
                     try:
-                        short_url = ShortUrl.objects.create(backend=self.class_path,
-                                                            original_url=original_url,
-                                                            shortened_url=shortened_url)
-                        log.info('Url "%s" shortened to "%s"', original_url, shortened_url)
+                        short_url, created = ShortUrl.objects.get_or_create(
+                            backend=self.class_path,
+                            original_url=original_url,
+                            defaults={'shortened_url': shortened_url})
+                        if created:
+                             log.info('Url "%s" shortened to "%s"',
+                                      original_url, shortened_url)
+                        else:
+                             log.info('Url "%s" already shortened to "%s"',
+                                      original_url, short_url.shortened_url)
                         transaction.savepoint_commit(sid)
                         return short_url
                     except (IntegrityError, ValidationError) as e:


### PR DESCRIPTION
If the initial get_or_create fails in shorten_url, we enter
an infinite loop of create() attempts. If the initial failure
was due to competition with another instance of trying to
shorten the same URL, then the subsequent create() call will
never succeed and the code will spin until killed.

This commit changes the retries to use get_or_create as well,
so that the retry will not try to create a short url that
already exists.

It might also be worth changing `while True` to something finite, like `for _ in range(20)`, but that is left for another day.
