### PR TITLE
use tox for tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,11 @@ To run the test run command: ::
 
  $ python manage.py test brevisurl
 
+Alternately, install tox to run tests against multiple versions
+of Python and Django: ::
+
+ $ pip install tox
+ $ tox
 
 Development setup
 -----------------

--- a/brevisurl/tests/backends/test_local.py
+++ b/brevisurl/tests/backends/test_local.py
@@ -1,7 +1,12 @@
-from django.db import transaction
 from django.core.exceptions import ValidationError
 from django.test import TestCase, TransactionTestCase
 from django.core.validators import URLValidator
+
+try:
+    from django.db.transaction import atomic
+except ImportError:
+    from django.db.transaction import commit_on_success as atomic
+
 
 import brevisurl.settings
 from brevisurl import get_connection
@@ -144,7 +149,7 @@ class TestDuration(TransactionTestCase):
             url = 'http://www.codescale.net/%s' % random.getrandbits(30)
             self.connection.shorten_url(url)
 
-    @transaction.commit_on_success
+    @atomic
     def test_shorten_urls_duration_commit_on_success(self):
         for i in range(0, 10000):
             url = 'http://www.codescale.net/%s' % random.getrandbits(30)

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import os
+import sys
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+
+def runtests():
+    try:
+        django.setup()
+    except AttributeError:
+        pass
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(["brevisurl"])
+    sys.exit(bool(failures))
+
+if __name__ == '__main__':
+    runtests()

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     download_url='http://github.com/char0n/django-brevisurl/tarball/master',
     license='BSD',
     keywords = 'url short shortener',
+    test_suite="runtests.runtests",
     packages=find_packages('.'),
     install_requires=['django', 'south'],
     platforms='any',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
 envlist = 
     py27-{15}
+    py27-{16}
 [testenv]
 deps =
     15: Django >= 1.5, < 1.6
+    16: Django >= 1.6, < 1.7
 commands = python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = 
+    py27-{15}
+[testenv]
+deps =
+    15: Django >= 1.5, < 1.6
+commands = python setup.py test


### PR DESCRIPTION
This is a suggestion rather than a fix. I was finding the existing Makefile a bit finicky about running tests -- I had to downgrade both Django (to 1.5) and pip before I could bootstrap the environment and run tests.

This is an example of integrating the tests into the existing setup.py, and creating a tox config for running tests with Django 1.5.x and Django 1.6.x. It also includes a small change to the tests of the local backend to address an error under Django 1.6 (with sqlite3).

Since testing is a subjective topic, I'll understand if you reject this change, but I offer it here in case it helps in moving this module forward to Django 1.8 and beyond. 
