### PR TITLE
Drop index on original_url and prevent a possible AttributeError exception

### DIFF
--- a/brevisurl/backends/local.py
+++ b/brevisurl/backends/local.py
@@ -53,7 +53,7 @@ class BrevisUrlBackend(BaseBrevisUrlBackend):
                 return short_url
             except (IntegrityError, ValidationError) as e:
                 # Check if the error is an URL validation error.
-                if e.message_dict.has_key('original_url'):
+                if isinstance(e, ValidationError) and e.message_dict.has_key('original_url'):
                     raise
 
                 # Generate another token.

--- a/brevisurl/backends/local.py
+++ b/brevisurl/backends/local.py
@@ -44,6 +44,7 @@ class BrevisUrlBackend(BaseBrevisUrlBackend):
             try:
                 short_url, created = ShortUrl.objects.get_or_create(backend=self.class_path,
                                                                     original_url=original_url,
+                                                                    original_url_hash=ShortUrl.url_hash(original_url),
                                                                     defaults={'shortened_url': shortened_url})
                 if created:
                      log.info('Url "%s" shortened to "%s"', original_url, shortened_url)

--- a/brevisurl/migrations/0003_auto__del_index_shorturl_original_url.py
+++ b/brevisurl/migrations/0003_auto__del_index_shorturl_original_url.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Removing index on 'ShortUrl', fields ['original_url']
+        db.delete_index(u'brevisurl_shorturl', ['original_url'])
+
+
+    def backwards(self, orm):
+        # Adding index on 'ShortUrl', fields ['original_url']
+        db.create_index(u'brevisurl_shorturl', ['original_url'])
+
+
+    models = {
+        u'brevisurl.shorturl': {
+            'Meta': {'ordering': "['-created']", 'unique_together': "(('original_url_hash', 'backend'),)", 'object_name': 'ShortUrl'},
+            'backend': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'original_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'original_url_hash': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'shortened_url': ('django.db.models.fields.URLField', [], {'unique': 'True', 'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['brevisurl']


### PR DESCRIPTION
If the original_url field is longer than its hash, then it is more effective to drop the index on original_url and use the index on original_url_hash. Less storage space is used and the queries are processed faster.

In my case the average length of the original URLs is 140 characters. I suppose that there are many cases when the original URLs are shorter then 64 characters and the index on original_url offers better performance than the index on original_url_hash. I think however that the index on original_url_hash offers a good middle ground.